### PR TITLE
Creates css colour variables

### DIFF
--- a/_sass/world/_colours.scss
+++ b/_sass/world/_colours.scss
@@ -1,0 +1,11 @@
+:root {
+  --red: #BF281C;
+  --purple-pale: #F3EDFF;
+  --purple-medium: #A386FF;
+  --purple-dark: #3B1D62;
+  --orange:  #D96242;
+  --pink-pale: #F8DBDB;;
+  --white: #FFFFFF;
+
+  --text-color: var(--white);
+}

--- a/assets/css/world.scss
+++ b/assets/css/world.scss
@@ -4,4 +4,5 @@
 @charset 'utf-8';
 
 @import 'base/reset';
+@import 'world/colours';
 @import 'world/metrics';


### PR DESCRIPTION
This PR creates CSS colour variables.
I've created variables for the card background, header, text color etc but I'm not sure if this should be declared here or in the card styling itself.

Atm I've included all the colours from the Figma design file, but I think the purple-pale colour might not end up being used, can remove if so.

